### PR TITLE
Fix public key URL

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,7 +5,7 @@ echo "%sudo ALL = NOPASSWD: ALL" >> /etc/sudoers
 
 # Public SSH key for vagrant user
 mkdir /home/vagrant/.ssh
-curl -s "https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub" -o /home/vagrant/.ssh/authorized_keys
+curl -s "https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub" -o /home/vagrant/.ssh/authorized_keys
 chmod 700 /home/vagrant/.ssh
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh


### PR DESCRIPTION
Github recently started serving raw content from a different domain, so this cURL command no longer works. The old domain redirects to the new domain, but because cURL was not invoked with the -L flag, it does not follow the redirect.

The URL has been updated to the new address.
