### PR TITLE
Preseed /dev/sda to install GRUB to

### DIFF
--- a/config/preseed.cfg
+++ b/config/preseed.cfg
@@ -60,6 +60,7 @@ d-i finish-install/keep-consoles boolean true
 
 d-i grub-installer/only_debian boolean true
 d-i base-installer/install-recommends boolean true
+d-i grub-installer/bootdev string /dev/sda
 
 tasksel tasksel/first multiselect
 popularity-contest popularity-contest/participate boolean false


### PR DESCRIPTION
This is needed by latest Debian Testing image generation.
