### PR TITLE
Getting current version number from the network install page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Install [Vagrant](http://www.vagrantup.com/downloads.html) and
     brew install fakeroot dvdrtools p7zip
     ./vagrant-debian 64
 
-## Debian Guide
+## Debian Stretch Guide
+
+Foloow the [Virtualbox Debian wiki page](https://wiki.debian.org/VirtualBox).
+
+    apt-get install fakeroot p7zip-full genisoimage vagrant virtualbox-5.1
+    ./vagrant-debian 64
+
+## Debian Jessie Guide
 
     apt-get install fakeroot p7zip-full genisoimage vagrant virtualbox virtualbox-guest-additions-iso
     ./vagrant-debian 64

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,7 +15,11 @@ gem install ohai
 gem install chef
 
 # Install guest additions on next boot
-cp /etc/rc.{local,local.bak} && cp /root/poststrap.sh /etc/rc.local
+# There is no /etc/rc.local in Debian Stretch
+if [ -f /etc/rc.local ]; then
+    cp /etc/rc.{local,local.bak}
+fi
+cp /root/poststrap.sh /etc/rc.local
 
 # Wait for disk
 sync

--- a/scripts/poststrap.sh
+++ b/scripts/poststrap.sh
@@ -10,4 +10,15 @@ mount /dev/cdrom /media/cdrom
 sh /media/cdrom/VBoxLinuxAdditions.run
 
 mv /etc/rc.local.bak /etc/rc.local
-shutdown -h now
+
+# Oldstable
+if [ -x /sbin/shudown ]; then
+    /sbin/shutdown -h now
+fi
+
+# Stable +
+if [ -x /bin/systemctl ]; then
+    /bin/systemctl poweroff
+fi
+
+# Otherwise shutdown the machine manually

--- a/vagrant-debian
+++ b/vagrant-debian
@@ -9,6 +9,15 @@ function usage {
   exit
 }
 
+function get-current-debian-version {
+    PAGE=$(curl -s https://www.debian.org/CD/netinst/)
+    if [[ $PAGE =~ \<a\ href=\"http:\/\/cdimage\.debian\.org\/debian-cd\/([0-9\.]+)\/amd64\/bt-cd\/debian-[0-9\.]+-amd64-netinst\.iso\.torrent ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        abort "Failed to get current stable version number. Aborting."
+    fi
+}
+
 argv=($@)
 
 case ${argv[0]} in
@@ -29,8 +38,7 @@ RELEASE_SPECIFIER="$2"
 case "$RELEASE_SPECIFIER" in
     "" | "stable")
         VERSION="current"
-        # TODO: current version number should be fetched from the net
-        VERSION_NUMBER="8.0.0"
+        VERSION_NUMBER=$(get-current-debian-version)
         MIRROR_DIR="release/${VERSION_NUMBER}"
     ;;
     "testing")

--- a/vagrant-debian
+++ b/vagrant-debian
@@ -11,7 +11,7 @@ function usage {
 
 function get-current-debian-version {
     PAGE=$(curl -s https://www.debian.org/CD/netinst/)
-    if [[ $PAGE =~ \<a\ href=\"http:\/\/cdimage\.debian\.org\/debian-cd\/([0-9\.]+)\/amd64\/bt-cd\/debian-[0-9\.]+-amd64-netinst\.iso\.torrent ]]; then
+    if [[ $PAGE =~ \<a\ href=\"https:\/\/cdimage\.debian\.org\/debian-cd\/current\/amd64\/bt-cd\/debian-([0-9\.]+)-amd64-netinst\.iso\.torrent ]]; then
         echo "${BASH_REMATCH[1]}"
     else
         abort "Failed to get current stable version number. Aborting."


### PR DESCRIPTION
Very simple way to determine current stable version number from the network install page (https://www.debian.org/CD/netinst/).
